### PR TITLE
Rewrite README: modernize layout, translate to French and simplify tech stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Mon cœur d'expertise est l'**écosystème Angular** : architecture de composant
 
 <div align="center">
 
-<img height="165" src="https://github-readme-stats-sigma-five.vercel.app/api?username=delitamakanda&show_icons=true&locale=en" alt="Statistiques GitHub de Délita Makanda" />
-<img height="165" src="https://github-readme-stats-sigma-five.vercel.app/api/top-langs?username=delitamakanda&show_icons=true&locale=en&layout=compact" alt="Langages les plus utilisés par Délita Makanda" />
+<img height="165" src="https://github-readme-stats-sigma-five.vercel.app/api?username=delitamakanda&show_icons=true&locale=fr" alt="Statistiques GitHub de Délita Makanda" />
+<img height="165" src="https://github-readme-stats-sigma-five.vercel.app/api/top-langs?username=delitamakanda&show_icons=true&locale=fr&layout=compact" alt="Langages les plus utilisés par Délita Makanda" />
 
 [![GitHub Streak](https://github-readme-streak-stats-k3nen14x3-delitamakanda.vercel.app?user=delitamakanda)](https://git.io/streak-stats)
 

--- a/README.md
+++ b/README.md
@@ -16,17 +16,16 @@
 
 ## 👋 À propos
 
-Je suis **développeuse frontend Angular senior**, spécialisée dans la conception d'applications web maintenables, performantes et orientées produit. J'aime transformer un besoin métier en interfaces claires, architectures frontend robustes et parcours utilisateurs fiables.
+Je suis **développeuse frontend Angular senior**, spécialisée dans la conception d'applications web performantes et orientées produit. J'aime transformer un besoin métier en interfaces claires, architectures frontend robustes et parcours utilisateurs fiables.
 
-Mon cœur d'expertise est l'**écosystème Angular** : architecture de composants, RxJS, formulaires, routing, performance, SSR, microfrontends et industrialisation frontend.
+Mon cœur d'expertise est l'**écosystème Angular** : architecture de composants, RxJS, formulaires, routing, performance et SSR.
 
 ### Ce que j'apporte à une équipe
 
 - **Expertise Angular senior** : architecture applicative, composants réutilisables, RxJS, formulaires, routing et maintenabilité.
-- **Vision produit** : compréhension des besoins utilisateurs, priorisation pragmatique et livraison de fonctionnalités utiles.
-- **Culture architecture frontend** : code structuré, patterns évolutifs, séparation des responsabilités et dette technique maîtrisée.
-- **Qualité logicielle** : lisibilité du code, tests, discipline de release, documentation et amélioration continue.
-- **Collaboration transverse** : échanges efficaces avec backend, design, produit, QA et parties prenantes métier.
+- **Vision produit** : compréhension des besoins utilisateurs, priorisation pragmatique et livraison de fonctionnalités.
+- **Qualité logicielle** : tests, release, séparation des responsabilités, documentation et amélioration continue.
+- **Collaboration transverse** : échanges avec backend, design, product owner, QA et équipes métier.
 
 ---
 
@@ -34,22 +33,18 @@ Mon cœur d'expertise est l'**écosystème Angular** : architecture de composant
 
 | Projet | Focus | Ce que le projet montre |
 | --- | --- | --- |
-| [Microfrontend](https://github.com/delitamakanda/microfrontend) | Angular · Architecture · Microfrontends | Capacité à structurer une application modulaire et à penser la scalabilité frontend. |
 | [Taiwan Travel](https://github.com/delitamakanda/angular-ssr-taiwan) | Angular · SSR · Expérience voyage | Mise en avant du SSR, de la performance, du SEO et d'une expérience produit soignée. |
 | [Angular QR Code Restaurant](https://github.com/delitamakanda/angular-qrcode-restaurant) | Angular · Parcours métier · QR Code | Implémentation d'un workflow concret, orienté usage et logique business. |
-| [Banky Front UI](https://github.com/delitamakanda/banky-front-ui) | UI engineering · Domaine finance | Travail d'interface structuré pour un contexte où clarté, cohérence et fiabilité sont essentielles. |
-| [Planner](https://github.com/delitamakanda/planner) | Productivité · Expérience frontend | Conception de fonctionnalités utiles, lisibles et adaptées à un usage quotidien. |
 
-> Mon GitHub est un portfolio vivant : projets, releases et activité montrent ma façon de structurer, itérer et livrer du logiciel.
+> Mon GitHub est un portfolio vivant : projets, releases et activité montrent ma façon de structurer, itérer et livrer des applications.
 
 ---
 
 ## 🧭 Focus actuel
 
-- Construire des **applications Angular** avec des standards d'architecture professionnels.
-- Explorer les **microfrontends** pour des plateformes frontend modulaires et évolutives.
+- Construire des **applications Angular** avec des standards professionnels actuels.
 - Améliorer le **SSR, la performance et le SEO** des applications web modernes.
-- Documenter et publier des projets avec une logique de release claire.
+- Documenter et publier des projets avec une logique de release claire et à terme l'automatiser.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Mon cœur d'expertise est l'**écosystème Angular** : architecture de composant
 
 ---
 
-## 🎧 Spotify Playing
+## 🎧 En écoute sur Spotify
 
 [<img src="https://spotify-now-playing-iota-three.vercel.app/api/spotify-playing" alt="Délita MAKANDA Spotify Playing" width="350" />](https://open.spotify.com/user/delita.makanda)
 

--- a/README.md
+++ b/README.md
@@ -1,165 +1,92 @@
-<h1 align="center">Hi 👋, I'm Délita Makanda</h1>
-<h3 align="center">A passionate angular senior frontend developer from France</h3>
+<div align="center">
 
-<p align="left"> <img src="https://komarev.com/ghpvc/?username=delitamakanda&label=Profile%20views&color=0e75b6&style=flat" alt="delitamakanda" /> </p>
+# Délita Makanda
 
-<p align="left"> <a href="https://github.com/delitamakanda/github-profile-trophy"><img src="https://github-profile-trophy-weld-theta.vercel.app/?username=delitamakanda&theme=light" alt="delitamakanda" /></a> </p>
+### Développeuse Frontend Angular Senior · Applications web & mobiles · France
 
-- 🔭 I’m currently working on [Microfrontend](https://github.com/delitamakanda/microfrontend) and [Taiwan Travel](https://github.com/delitamakanda/angular-ssr-taiwan)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-delitamakanda-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/delitamakanda)
+[![Email](https://img.shields.io/badge/Email-contact-2A8?style=for-the-badge&logo=gmail&logoColor=white)](https://mailhide.io/e/7Z9YnmXq)
+[![GitHub](https://img.shields.io/badge/GitHub-delitamakanda-181717?style=for-the-badge&logo=github&logoColor=white)](https://github.com/delitamakanda)
 
-- 🌱 I build web and mobile applications with **Angular + React + Vue**
+<img src="https://komarev.com/ghpvc/?username=delitamakanda&label=Profile%20views&color=0e75b6&style=flat" alt="Profile views" />
 
-- 👨‍💻 All of my projects are available at [https://github.com/delitamakanda](https://github.com/delitamakanda)
+</div>
 
-- 💬 Ask me about **Django and Javascript**
+---
 
-- 📫 How to reach me [![E-Mail](https://img.shields.io/badge/email-reveal-2a8?style=flat-square&logo=gmail&logoColor=white)](https://mailhide.io/e/7Z9YnmXq)
+## 👋 À propos
 
-- 📄 Know about my experiences [www.linkedin.com/in/delitamakanda](https://www.linkedin.com/in/delitamakanda)
+Je suis **développeuse frontend Angular senior**, spécialisée dans la conception d'applications web maintenables, performantes et orientées produit. J'aime transformer un besoin métier en interfaces claires, architectures frontend robustes et parcours utilisateurs fiables.
 
-- ⚡ Fun fact **I love working**
+Mon cœur d'expertise est l'**écosystème Angular** : architecture de composants, RxJS, formulaires, routing, performance, SSR, microfrontends et industrialisation frontend.
 
-<h3 align="left">Connect with me:</h3>
-<p align="left">
-<a href="https://linkedin.com/in/delitamakanda" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/linked-in-alt.svg" alt="delitamakanda" height="30" width="40" /></a>
-</p>
+### Ce que j'apporte à une équipe
 
-## Tech Stack
+- **Expertise Angular senior** : architecture applicative, composants réutilisables, RxJS, formulaires, routing et maintenabilité.
+- **Vision produit** : compréhension des besoins utilisateurs, priorisation pragmatique et livraison de fonctionnalités utiles.
+- **Culture architecture frontend** : code structuré, patterns évolutifs, séparation des responsabilités et dette technique maîtrisée.
+- **Qualité logicielle** : lisibilité du code, tests, discipline de release, documentation et amélioration continue.
+- **Collaboration transverse** : échanges efficaces avec backend, design, produit, QA et parties prenantes métier.
 
-<table>
-  <tr>
-    <td valign="top" width="25%">
-      <h3>Frontend</h3>
-      <p>
-        <a href="https://angular.io" target="_blank" rel="noreferrer">
-          <img src="https://angular.io/assets/images/logos/angular/angular.svg" alt="Angular" width="40" height="40"/>
-        </a>
-        <a href="https://reactjs.org/" target="_blank" rel="noreferrer">
-          <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/react/react-original-wordmark.svg" alt="React" width="40" height="40"/>
-        </a>
-        <a href="https://vuejs.org/" target="_blank" rel="noreferrer">
-          <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/vuejs/vuejs-original-wordmark.svg" alt="Vue.js" width="40" height="40"/>
-        </a>
-        <a href="https://nextjs.org/" target="_blank" rel="noreferrer">
-          <img src="https://cdn.worldvectorlogo.com/logos/nextjs-2.svg" alt="Next.js" width="40" height="40"/>
-        </a>
-        <a href="https://nuxtjs.org/" target="_blank" rel="noreferrer">
-          <img src="https://www.vectorlogo.zone/logos/nuxtjs/nuxtjs-icon.svg" alt="Nuxt.js" width="40" height="40"/>
-        </a>
-        <a href="https://ionicframework.com" target="_blank" rel="noreferrer">
-          <img src="https://upload.wikimedia.org/wikipedia/commons/d/d1/Ionic_Logo.svg" alt="Ionic" width="40" height="40"/>
-        </a>
-        <a href="https://cordova.apache.org/" target="_blank" rel="noreferrer">
-          <img src="https://www.vectorlogo.zone/logos/apache_cordova/apache_cordova-icon.svg" alt="Cordova" width="40" height="40"/>
-        </a>
-        <a href="https://getbootstrap.com" target="_blank" rel="noreferrer">
-          <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/bootstrap/bootstrap-plain-wordmark.svg" alt="Bootstrap" width="40" height="40"/>
-        </a>
-        <a href="https://vuetifyjs.com/en/" target="_blank" rel="noreferrer">
-          <img src="https://bestofjs.org/logos/vuetify.svg" alt="Vuetify" width="40" height="40"/>
-        </a>
-      </p>
-    </td>
-    <td valign="top" width="25%">
-      <h3>Languages</h3>
-      <p>
-        <a href="https://www.w3.org/html/" target="_blank" rel="noreferrer">
-          <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/html5/html5-original-wordmark.svg" alt="HTML5" width="40" height="40"/>
-        </a>
-        <a href="https://www.w3schools.com/css/" target="_blank" rel="noreferrer">
-          <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/css3/css3-original-wordmark.svg" alt="CSS3" width="40" height="40"/>
-        </a>
-        <a href="https://sass-lang.com" target="_blank" rel="noreferrer">
-          <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/sass/sass-original.svg" alt="Sass" width="40" height="40"/>
-        </a>
-        <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript" target="_blank" rel="noreferrer">
-          <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/javascript/javascript-original.svg" alt="JavaScript" width="40" height="40"/>
-        </a>
-        <a href="https://www.typescriptlang.org/" target="_blank" rel="noreferrer">
-          <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/typescript/typescript-original.svg" alt="TypeScript" width="40" height="40"/>
-        </a>
-        <a href="https://www.python.org" target="_blank" rel="noreferrer">
-          <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="Python" width="40" height="40"/>
-        </a>
-      </p>
-    </td>
-    <td valign="top" width="25%">
-      <h3>Backend & Data</h3>
-      <p>
-        <a href="https://www.djangoproject.com/" target="_blank" rel="noreferrer">
-          <img src="https://cdn.worldvectorlogo.com/logos/django.svg" alt="Django" width="40" height="40"/>
-        </a>
-        <a href="https://graphql.org" target="_blank" rel="noreferrer">
-          <img src="https://www.vectorlogo.zone/logos/graphql/graphql-icon.svg" alt="GraphQL" width="40" height="40"/>
-        </a>
-        <a href="https://firebase.google.com/" target="_blank" rel="noreferrer">
-          <img src="https://www.vectorlogo.zone/logos/firebase/firebase-icon.svg" alt="Firebase" width="40" height="40"/>
-        </a>
-        <a href="https://www.mysql.com/" target="_blank" rel="noreferrer">
-          <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/mysql/mysql-original-wordmark.svg" alt="MySQL" width="40" height="40"/>
-        </a>
-        <a href="https://www.postgresql.org" target="_blank" rel="noreferrer">
-          <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/postgresql/postgresql-original-wordmark.svg" alt="PostgreSQL" width="40" height="40"/>
-        </a>
-        <a href="https://redis.io" target="_blank" rel="noreferrer">
-          <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/redis/redis-original-wordmark.svg" alt="Redis" width="40" height="40"/>
-        </a>
-      </p>
-    </td>
-    <td valign="top" width="25%">
-      <h3>Cloud, Tools & Design</h3>
-      <p>
-        <a href="https://aws.amazon.com" target="_blank" rel="noreferrer">
-          <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/amazonwebservices/amazonwebservices-original-wordmark.svg" alt="AWS" width="40" height="40"/>
-        </a>
-        <a href="https://azure.microsoft.com/en-in/" target="_blank" rel="noreferrer">
-          <img src="https://www.vectorlogo.zone/logos/microsoft_azure/microsoft_azure-icon.svg" alt="Azure" width="40" height="40"/>
-        </a>
-        <a href="https://cloud.google.com" target="_blank" rel="noreferrer">
-          <img src="https://www.vectorlogo.zone/logos/google_cloud/google_cloud-icon.svg" alt="GCP" width="40" height="40"/>
-        </a>
-        <a href="https://heroku.com" target="_blank" rel="noreferrer">
-          <img src="https://www.vectorlogo.zone/logos/heroku/heroku-icon.svg" alt="Heroku" width="40" height="40"/>
-        </a>
-        <a href="https://webpack.js.org" target="_blank" rel="noreferrer">
-          <img src="https://raw.githubusercontent.com/devicons/devicon/d00d0969292a6569d45b06d3f350f463a0107b0d/icons/webpack/webpack-original-wordmark.svg" alt="Webpack" width="40" height="40"/>
-        </a>
-        <a href="https://babeljs.io/" target="_blank" rel="noreferrer">
-          <img src="https://www.vectorlogo.zone/logos/babeljs/babeljs-icon.svg" alt="Babel" width="40" height="40"/>
-        </a>
-        <a href="https://gulpjs.com" target="_blank" rel="noreferrer">
-          <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/gulp/gulp-plain.svg" alt="Gulp" width="40" height="40"/>
-        </a>
-        <a href="https://git-scm.com/" target="_blank" rel="noreferrer">
-          <img src="https://www.vectorlogo.zone/logos/git-scm/git-scm-icon.svg" alt="Git" width="40" height="40"/>
-        </a>
-        <a href="https://jestjs.io" target="_blank" rel="noreferrer">
-          <img src="https://www.vectorlogo.zone/logos/jestjsio/jestjsio-icon.svg" alt="Jest" width="40" height="40"/>
-        </a>
-        <a href="https://www.selenium.dev" target="_blank" rel="noreferrer">
-          <img src="https://raw.githubusercontent.com/detain/svg-logos/780f25886640cef088af994181646db2f6b1a3f8/svg/selenium-logo.svg" alt="Selenium" width="40" height="40"/>
-        </a>
-        <a href="https://www.chartjs.org" target="_blank" rel="noreferrer">
-          <img src="https://www.chartjs.org/media/logo-title.svg" alt="Chart.js" width="40" height="40"/>
-        </a>
-        <a href="https://d3js.org/" target="_blank" rel="noreferrer">
-          <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/d3js/d3js-original.svg" alt="D3.js" width="40" height="40"/>
-        </a>
-        <a href="https://www.figma.com/" target="_blank" rel="noreferrer">
-          <img src="https://www.vectorlogo.zone/logos/figma/figma-icon.svg" alt="Figma" width="40" height="40"/>
-        </a>
-      </p>
-    </td>
-  </tr>
-</table>
+---
 
-<p><img align="left" src="https://github-readme-stats-sigma-five.vercel.app/api/top-langs?username=delitamakanda&show_icons=true&locale=en&layout=compact" alt="delitamakanda" /></p>
+## 🚀 Projets mis en avant
 
-<p>&nbsp;<img align="center" src="https://github-readme-stats-sigma-five.vercel.app/api?username=delitamakanda&show_icons=true&locale=en" alt="delitamakanda" /></p>
+| Projet | Focus | Ce que le projet montre |
+| --- | --- | --- |
+| [Microfrontend](https://github.com/delitamakanda/microfrontend) | Angular · Architecture · Microfrontends | Capacité à structurer une application modulaire et à penser la scalabilité frontend. |
+| [Taiwan Travel](https://github.com/delitamakanda/angular-ssr-taiwan) | Angular · SSR · Expérience voyage | Mise en avant du SSR, de la performance, du SEO et d'une expérience produit soignée. |
+| [Angular QR Code Restaurant](https://github.com/delitamakanda/angular-qrcode-restaurant) | Angular · Parcours métier · QR Code | Implémentation d'un workflow concret, orienté usage et logique business. |
+| [Banky Front UI](https://github.com/delitamakanda/banky-front-ui) | UI engineering · Domaine finance | Travail d'interface structuré pour un contexte où clarté, cohérence et fiabilité sont essentielles. |
+| [Planner](https://github.com/delitamakanda/planner) | Productivité · Expérience frontend | Conception de fonctionnalités utiles, lisibles et adaptées à un usage quotidien. |
 
-[![GitHub Streak](https://github-readme-streak-stats-k3nen14x3-delitamakanda.vercel.app?user=delitamakanda)](https://git.io/streak-stats)
+> Mon GitHub est un portfolio vivant : projets, releases et activité montrent ma façon de structurer, itérer et livrer du logiciel.
 
-<h3 align="left">Recent releases</h3>
+---
+
+## 🧭 Focus actuel
+
+- Construire des **applications Angular** avec des standards d'architecture professionnels.
+- Explorer les **microfrontends** pour des plateformes frontend modulaires et évolutives.
+- Améliorer le **SSR, la performance et le SEO** des applications web modernes.
+- Documenter et publier des projets avec une logique de release claire.
+
+---
+
+## 🛠️ Stack technique
+
+### Frontend principal
+
+![Angular](https://img.shields.io/badge/Angular-DD0031?style=flat-square&logo=angular&logoColor=white)
+![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white)
+![RxJS](https://img.shields.io/badge/RxJS-B7178C?style=flat-square&logo=reactivex&logoColor=white)
+![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=flat-square&logo=javascript&logoColor=black)
+![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=flat-square&logo=html5&logoColor=white)
+![CSS3](https://img.shields.io/badge/CSS3-1572B6?style=flat-square&logo=css3&logoColor=white)
+![Sass](https://img.shields.io/badge/Sass-CC6699?style=flat-square&logo=sass&logoColor=white)
+
+### Écosystèmes frontend complémentaires
+
+![React](https://img.shields.io/badge/React-61DAFB?style=flat-square&logo=react&logoColor=black)
+![Vue.js](https://img.shields.io/badge/Vue.js-4FC08D?style=flat-square&logo=vuedotjs&logoColor=white)
+![Next.js](https://img.shields.io/badge/Next.js-000000?style=flat-square&logo=nextdotjs&logoColor=white)
+![Nuxt](https://img.shields.io/badge/Nuxt-00DC82?style=flat-square&logo=nuxtdotjs&logoColor=white)
+![Ionic](https://img.shields.io/badge/Ionic-3880FF?style=flat-square&logo=ionic&logoColor=white)
+
+### Backend, data & outillage
+
+![Django](https://img.shields.io/badge/Django-092E20?style=flat-square&logo=django&logoColor=white)
+![Python](https://img.shields.io/badge/Python-3776AB?style=flat-square&logo=python&logoColor=white)
+![GraphQL](https://img.shields.io/badge/GraphQL-E10098?style=flat-square&logo=graphql&logoColor=white)
+![Firebase](https://img.shields.io/badge/Firebase-FFCA28?style=flat-square&logo=firebase&logoColor=black)
+![Git](https://img.shields.io/badge/Git-F05032?style=flat-square&logo=git&logoColor=white)
+![Jest](https://img.shields.io/badge/Jest-C21325?style=flat-square&logo=jest&logoColor=white)
+![Webpack](https://img.shields.io/badge/Webpack-8DD6F9?style=flat-square&logo=webpack&logoColor=black)
+![Figma](https://img.shields.io/badge/Figma-F24E1E?style=flat-square&logo=figma&logoColor=white)
+
+---
+
+## 📦 Releases récentes
 
 <!-- recent_releases starts -->
 * [special-rotary-phone v0.2.0-alpha](https://github.com/delitamakanda/special-rotary-phone/releases/tag/v0.2.0-alpha) - 2026-05-22
@@ -171,14 +98,27 @@
 * [banky-front-ui v1.0.0](https://github.com/delitamakanda/banky-front-ui/releases/tag/v1.0.0) - 2025-12-14
 * [faq-worker v1.0.0](https://github.com/delitamakanda/faq-worker/releases/tag/v1.0.0) - 2025-10-29
 <!-- recent_releases ends -->
-More [recent releases](https://github.com/delitamakanda/delitamakanda/blob/master/releases.md)
 
+➡️ Voir toutes les [releases récentes](https://github.com/delitamakanda/delitamakanda/blob/master/releases.md)
+
+---
+
+## 📊 Aperçu GitHub
+
+<div align="center">
+
+<img height="165" src="https://github-readme-stats-sigma-five.vercel.app/api?username=delitamakanda&show_icons=true&locale=en" alt="Statistiques GitHub de Délita Makanda" />
+<img height="165" src="https://github-readme-stats-sigma-five.vercel.app/api/top-langs?username=delitamakanda&show_icons=true&locale=en&layout=compact" alt="Langages les plus utilisés par Délita Makanda" />
+
+[![GitHub Streak](https://github-readme-streak-stats-k3nen14x3-delitamakanda.vercel.app?user=delitamakanda)](https://git.io/streak-stats)
+
+</div>
 
 ---
 
 <details>
-  <summary>:zap: Recent GitHub Activity</summary>
-  
+  <summary>⚡ Activité GitHub récente</summary>
+
 <!--START_SECTION:activity-->
 1. ℹ️ Assigned issue [#77](https://github.com/delitamakanda/angular-qrcode-restaurant/issues/77) in [delitamakanda/angular-qrcode-restaurant](https://github.com/delitamakanda/angular-qrcode-restaurant)
 2. 🎉 Merged PR [#156](https://github.com/delitamakanda/angular-qrcode-restaurant/pull/156) in [delitamakanda/angular-qrcode-restaurant](https://github.com/delitamakanda/angular-qrcode-restaurant)
@@ -188,10 +128,17 @@ More [recent releases](https://github.com/delitamakanda/delitamakanda/blob/maste
 
 </details>
 
-<a href="https://github.com/delitamakanda/delitamakanda/actions"><img src="https://github.com/delitamakanda/delitamakanda/workflows/Build%20README/badge.svg" align="right" alt="Build README"></a>
+---
 
-### Spotify Playing 🎧
+## 🎧 Spotify Playing
 
 [<img src="https://spotify-now-playing-iota-three.vercel.app/api/spotify-playing" alt="Délita MAKANDA Spotify Playing" width="350" />](https://open.spotify.com/user/delita.makanda)
 
+---
+
+## 🤝 Me contacter
+
+Si vous recherchez une **développeuse frontend Angular senior** capable de contribuer à l'architecture, à la qualité de livraison et à l'expérience produit, vous pouvez me contacter sur [LinkedIn](https://www.linkedin.com/in/delitamakanda) ou par [email](https://mailhide.io/e/7Z9YnmXq).
+
+<a href="https://github.com/delitamakanda/delitamakanda/actions"><img src="https://github.com/delitamakanda/delitamakanda/workflows/Build%20README/badge.svg" align="right" alt="Build README"></a>
 


### PR DESCRIPTION
### Motivation

- Modernize and simplify the repository `README.md` to present a clearer professional profile focused on Angular frontend expertise.  
- Translate and localize the content to French while improving readability and visual hierarchy.  
- Replace verbose image-heavy sections with compact badge-based stack and curated project highlights for better maintainability.  

### Description

- Rewrote `README.md` from a long English HTML-heavy layout to a concise French profile with a centered header, badges, and a short bio.  
- Removed the large tech-table of inline SVG images and introduced categorized shield-style badges for frontend, ecosystems, and backend/tools.  
- Added a focused "Projets mis en avant" table, a curated "Focus actuel" list, and a formatted recent releases list.  
- Kept GitHub stats, activity section and the `Build README` badge while simplifying markup and removing excess HTML.  

### Testing

- Triggered the GitHub Actions `Build README` workflow for `README.md`, and the workflow completed successfully.  
- No runtime code changes were made, so no unit or integration tests were required or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a218ddd952883328d71e8a1496367e9)